### PR TITLE
feat(form): add 小学校2年生 option to start grade select

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,8 @@
             <div class="control">
               <div class="select">
                 <select id="startGrade" required>
-                  <option value="小3">小学校3年生</option>
+                  <option value="小2">小学校2年生</option>
+                  <option value="小3" selected>小学校3年生</option>
                   <option value="小4">小学校4年生</option>
                   <option value="小5">小学校5年生</option>
                   <option value="小6">小学校6年生</option>

--- a/script.js
+++ b/script.js
@@ -46,6 +46,7 @@ function calculateLevels() {
   // 学年を進めるための関数
   function getNextGrade(grade) {
     const gradeOrder = [
+      '小2',
       '小3',
       '小4',
       '小5',


### PR DESCRIPTION
- Add "小学校2年生" (`小2`) as a selectable start grade in the dropdown
- Update grade progression logic to include "小2" in grade order array